### PR TITLE
[BUGFIX] Added wrappers for malloc and free

### DIFF
--- a/libs/wrappers.h
+++ b/libs/wrappers.h
@@ -1,0 +1,31 @@
+#ifndef WRAPPERS_H
+# define WRAPPERS_H
+
+#include <stdlib.h>
+
+void *__real_malloc(size_t size);
+void __real_free(void *ptr);
+
+void *__wrap_malloc(size_t size)
+{
+    size_t *ptr = __real_malloc(size + sizeof(size_t));
+    *ptr = size;
+    ptr++;
+    return ptr;
+}
+
+void __wrap_free(void *ptr)
+{
+    size_t *p = ptr;
+    p--;
+    __real_free(p);
+}
+
+size_t allocated_size(void *ptr)
+{
+    size_t *p = ptr;
+    p--;
+    return (*p);
+}
+
+#endif

--- a/tests/X/test00_basic.c
+++ b/tests/X/test00_basic.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 
 #define TESTED_INT 42

--- a/tests/X/test01_negative.c
+++ b/tests/X/test01_negative.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 
 #define TESTED_INT -42

--- a/tests/X/test02_zero.c
+++ b/tests/X/test02_zero.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 
 #define TESTED_INT 0

--- a/tests/X/test03_max.c
+++ b/tests/X/test03_max.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 #include <limits.h>
 

--- a/tests/X/test04_min.c
+++ b/tests/X/test04_min.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 #include <limits.h>
 

--- a/tests/X/test05_max_long.c
+++ b/tests/X/test05_max_long.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 #include <limits.h>
 

--- a/tests/X/test06_min_long.c
+++ b/tests/X/test06_min_long.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 #include <limits.h>
 

--- a/tests/X/test07_ten.c
+++ b/tests/X/test07_ten.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 
 #define TESTED_INT 10

--- a/tests/basic/test00_basic.c
+++ b/tests/basic/test00_basic.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 
 int     main(void)

--- a/tests/basic/test01_empty.c
+++ b/tests/basic/test01_empty.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 
 int     main(void)

--- a/tests/basic/test02_mixed_up.c
+++ b/tests/basic/test02_mixed_up.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 
 int     main(void)

--- a/tests/c/test00_basic.c
+++ b/tests/c/test00_basic.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 
 #define TESTED_INT 42

--- a/tests/c/test01_negative.c
+++ b/tests/c/test01_negative.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 
 #define TESTED_INT -42

--- a/tests/c/test02_zero.c
+++ b/tests/c/test02_zero.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 
 #define TESTED_INT 0

--- a/tests/c/test03_max.c
+++ b/tests/c/test03_max.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 #include <limits.h>
 

--- a/tests/c/test04_min.c
+++ b/tests/c/test04_min.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 #include <limits.h>
 

--- a/tests/c/test05_max_long.c
+++ b/tests/c/test05_max_long.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 #include <limits.h>
 

--- a/tests/c/test06_min_long.c
+++ b/tests/c/test06_min_long.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 #include <limits.h>
 

--- a/tests/c/test07_ten.c
+++ b/tests/c/test07_ten.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 
 #define TESTED_INT 10

--- a/tests/d/test00_basic.c
+++ b/tests/d/test00_basic.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 
 #define TESTED_INT 42

--- a/tests/d/test01_negative.c
+++ b/tests/d/test01_negative.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 
 #define TESTED_INT -42

--- a/tests/d/test02_zero.c
+++ b/tests/d/test02_zero.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 
 #define TESTED_INT 0

--- a/tests/d/test03_max.c
+++ b/tests/d/test03_max.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 #include <limits.h>
 

--- a/tests/d/test04_min.c
+++ b/tests/d/test04_min.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 #include <limits.h>
 

--- a/tests/d/test05_max_long.c
+++ b/tests/d/test05_max_long.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 #include <limits.h>
 

--- a/tests/d/test06_min_long.c
+++ b/tests/d/test06_min_long.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 #include <limits.h>
 

--- a/tests/d/test07_ten.c
+++ b/tests/d/test07_ten.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 
 #define TESTED_INT 10

--- a/tests/i/test00_basic.c
+++ b/tests/i/test00_basic.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 
 #define TESTED_INT 42

--- a/tests/i/test01_negative.c
+++ b/tests/i/test01_negative.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 
 #define TESTED_INT -42

--- a/tests/i/test02_zero.c
+++ b/tests/i/test02_zero.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 
 #define TESTED_INT 0

--- a/tests/i/test03_max.c
+++ b/tests/i/test03_max.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 #include <limits.h>
 

--- a/tests/i/test04_min.c
+++ b/tests/i/test04_min.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 #include <limits.h>
 

--- a/tests/i/test05_max_long.c
+++ b/tests/i/test05_max_long.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 #include <limits.h>
 

--- a/tests/i/test06_min_long.c
+++ b/tests/i/test06_min_long.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 #include <limits.h>
 

--- a/tests/i/test07_ten.c
+++ b/tests/i/test07_ten.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 
 #define TESTED_INT 10

--- a/tests/p/test00_basic.c
+++ b/tests/p/test00_basic.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 
 int     main(void)

--- a/tests/p/test01_empty.c
+++ b/tests/p/test01_empty.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 
 #define TESTED_STRING ""

--- a/tests/p/test02_null.c
+++ b/tests/p/test02_null.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 #include <string.h>
 

--- a/tests/p/test03_int_max.c
+++ b/tests/p/test03_int_max.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 #include <limits.h>
 

--- a/tests/p/test04_int_min.c
+++ b/tests/p/test04_int_min.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 #include <limits.h>
 

--- a/tests/p/test05_long_max.c
+++ b/tests/p/test05_long_max.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 #include <limits.h>
 

--- a/tests/p/test06_long_min.c
+++ b/tests/p/test06_long_min.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 #include <limits.h>
 

--- a/tests/percent/test00_basic.c
+++ b/tests/percent/test00_basic.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 
 int     main(void)

--- a/tests/percent/test01_many.c
+++ b/tests/percent/test01_many.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 
 int     main(void)

--- a/tests/s/test00_basic.c
+++ b/tests/s/test00_basic.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 
 #define TESTED_STRING "Some basic string"

--- a/tests/s/test01_empty.c
+++ b/tests/s/test01_empty.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 
 #define TESTED_STRING ""

--- a/tests/s/test02_null.c
+++ b/tests/s/test02_null.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 #include <string.h>
 

--- a/tests/u/test00_basic.c
+++ b/tests/u/test00_basic.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 
 #define TESTED_INT 42

--- a/tests/u/test01_negative.c
+++ b/tests/u/test01_negative.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 
 #define TESTED_INT -42

--- a/tests/u/test02_zero.c
+++ b/tests/u/test02_zero.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 
 #define TESTED_INT 0

--- a/tests/u/test03_max.c
+++ b/tests/u/test03_max.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 #include <limits.h>
 

--- a/tests/u/test04_min.c
+++ b/tests/u/test04_min.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 #include <limits.h>
 

--- a/tests/u/test05_max_long.c
+++ b/tests/u/test05_max_long.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 #include <limits.h>
 

--- a/tests/u/test06_min_long.c
+++ b/tests/u/test06_min_long.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 #include <limits.h>
 

--- a/tests/u/test07_ten.c
+++ b/tests/u/test07_ten.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 
 #define TESTED_INT 10

--- a/tests/x/test00_basic.c
+++ b/tests/x/test00_basic.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 
 #define TESTED_INT 42

--- a/tests/x/test01_negative.c
+++ b/tests/x/test01_negative.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 
 #define TESTED_INT -42

--- a/tests/x/test02_zero.c
+++ b/tests/x/test02_zero.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 
 #define TESTED_INT 0

--- a/tests/x/test03_max.c
+++ b/tests/x/test03_max.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 #include <limits.h>
 

--- a/tests/x/test04_min.c
+++ b/tests/x/test04_min.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 #include <limits.h>
 

--- a/tests/x/test05_max_long.c
+++ b/tests/x/test05_max_long.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 #include <limits.h>
 

--- a/tests/x/test06_min_long.c
+++ b/tests/x/test06_min_long.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 #include <limits.h>
 

--- a/tests/x/test07_ten.c
+++ b/tests/x/test07_ten.c
@@ -1,4 +1,6 @@
 #include "libft.h"
+#include "wrappers.h"
+
 #include <stdio.h>
 
 #define TESTED_INT 10


### PR DESCRIPTION
If we have _**malloc**_ in our **_Printf_**, the tester will fail to compile due to missing wrappers.

```
/usr/bin/ld: libs/libftprintf.a(ft_print_nbr.o): in function `ft_itoa':
ft_print_nbr.c:(.text+0x2c): undefined reference to `__wrap_malloc'
/usr/bin/ld: libs/libftprintf.a(ft_print_nbr.o): in function `ft_print_nbr':
ft_print_nbr.c:(.text+0x17f): undefined reference to `__wrap_free'
/usr/bin/ld: libs/libftprintf.a(ft_print_unsigned.o): in function `ft_uitoa':
ft_print_unsigned.c:(.text+0x64): undefined reference to `__wrap_malloc'
/usr/bin/ld: libs/libftprintf.a(ft_print_unsigned.o): in function `ft_print_unsigned':
ft_print_unsigned.c:(.text+0x157): undefined reference to `__wrap_free'
clang: error: linker command failed with exit code 1 (use -v to see invocation)

```

I added a **_wrappers.h_** with the needed files.